### PR TITLE
Padronização de controllers

### DIFF
--- a/infra/controllers.js
+++ b/infra/controllers.js
@@ -1,0 +1,31 @@
+import { InternalServerError, MethodNotAllowedError } from "./errors";
+
+// handlers para requisições via next-connect
+
+
+function onErrorHandler(error, req, res) {
+  const publicErrorObj = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObj);
+
+  res.status(publicErrorObj.statusCode).json(publicErrorObj);
+}
+
+function onNoMatchHandler(req, res) {
+  const errorMethodNotAllowed = new MethodNotAllowedError();
+  res.status(errorMethodNotAllowed.statusCode).json(errorMethodNotAllowed);
+}
+
+const defaulRoutetHandlerOptions = {
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+};
+
+const controllerExports = {
+  errorHandlers: defaulRoutetHandlerOptions
+}
+
+export default controllerExports;

--- a/infra/controllers.js
+++ b/infra/controllers.js
@@ -2,7 +2,6 @@ import { InternalServerError, MethodNotAllowedError } from "./errors";
 
 // handlers para requisições via next-connect
 
-
 function onErrorHandler(error, req, res) {
   const publicErrorObj = new InternalServerError({
     statusCode: error.statusCode,
@@ -25,7 +24,7 @@ const defaulRoutetHandlerOptions = {
 };
 
 const controllerExports = {
-  errorHandlers: defaulRoutetHandlerOptions
-}
+  errorHandlers: defaulRoutetHandlerOptions,
+};
 
 export default controllerExports;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 async function query(queryObj) {
   let result = null;
@@ -7,9 +8,11 @@ async function query(queryObj) {
     client = await getNewClient();
     result = await client.query(queryObj);
   } catch (error) {
-    console.log("\n Erro dentro do catch do database.js:");
-    console.error(error);
-    throw error;
+    const serviceErrorobj = new ServiceError({
+      message: "Erro na conexão com Banco ou na query",
+      cause: error
+    });
+    throw serviceErrorobj;
   } finally {
     await client?.end();
   }

--- a/infra/database.js
+++ b/infra/database.js
@@ -10,7 +10,7 @@ async function query(queryObj) {
   } catch (error) {
     const serviceErrorobj = new ServiceError({
       message: "Erro na conexão com Banco ou na query",
-      cause: error
+      cause: error,
     });
     throw serviceErrorobj;
   } finally {

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,11 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause: cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
   }
 
   toJSON() {
@@ -13,7 +13,46 @@ export class InternalServerError extends Error {
       name: this.name,
       message: this.message,
       action: this.action,
-      statusCode: this.statusCode,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o metodo HTTP enviado é valido para este endpoint.";
+    this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponével no momento.", {
+      cause: cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
     };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.11",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2035,6 +2036,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8053,6 +8060,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8919,6 +8939,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.11",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,35 +1,33 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import controllers from "infra/controllers";
 
-export default async function status(req, res) {
-  try {
-    const dbVersion = await database.query("SHOW server_version;");
+const router = createRouter();
 
-    const dbMaxCons = await database.query("SHOW MAX_CONNECTIONS;");
+router.get(getHandler);
 
-    const databaseName = process.env.POSTGRES_DB;
-    const dbCurrentCons = await database.query({
-      text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
+export default router.handler(controllers.errorHandlers);
 
-    const updatedAt = new Date().toISOString();
-    res.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: dbVersion.rows[0].server_version,
-          max_connections: parseInt(dbMaxCons.rows[0].max_connections),
-          current_connections: dbCurrentCons.rows[0].count,
-        },
+async function getHandler(req, res) {
+  const dbVersion = await database.query("SHOW server_version;");
+
+  const dbMaxCons = await database.query("SHOW MAX_CONNECTIONS;");
+
+  const databaseName = process.env.POSTGRES_DB;
+  const dbCurrentCons = await database.query({
+    text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+
+  const updatedAt = new Date().toISOString();
+  res.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: dbVersion.rows[0].server_version,
+        max_connections: parseInt(dbMaxCons.rows[0].max_connections),
+        current_connections: dbCurrentCons.rows[0].count,
       },
-    });
-  } catch (error) {
-    const publicErrorObj = new InternalServerError({
-      cause: error,
-    });
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObj);
-    res.status(500).json(publicErrorObj);
-  }
+    },
+  });
 }

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -6,16 +6,11 @@ beforeAll(async () => {
 
 const baseUrl = process.env.SITE_URL;
 
-beforeAll(cleanDatabase);
-async function cleanDatabase() {
-  await orchestrator.cleanDatabase();
-}
-
-describe("PUT /api/v1/migrations", () => {
+describe("POST /api/v1/status", () => {
   describe("Anonymous user", () => {
-    test("Should return a MethodNotAllowedError", async () => {
+    test("Should return 405", async () => {
       const res = await fetch(baseUrl + "/api/v1/status", {
-        method: "PUT",
+        method: "POST",
       });
       expect(res.status).toBe(405);
 


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`. 
4. Faz o `InternalServerError` aceitar injeção do `statusCode`.